### PR TITLE
test(VDF): add bench tests for VDF in class group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "class_group"
-version = "0.4.17"
+version = "0.4.18"
 authors = ["omershlo <omer.shlomovits@gmail.com>"]
 edition = "2018"
 links = "libpari"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,12 @@ git = "https://github.com/KZen-networks/curv"
 tag = "v0.2.6"
 features =  ["ec_secp256k1"]
 
+[dev-dependencies]
+criterion = ">=0.2"
+rug = "1.2.1"
+sha2 = "0.9.1"
 
+[[bench]]
+name = "bench-vdf-class"
+path = "benches/vdf/class_group.rs"
+harness = false

--- a/benches/vdf/class_group.rs
+++ b/benches/vdf/class_group.rs
@@ -1,0 +1,43 @@
+#[macro_use]
+extern crate criterion;
+
+use class_group::primitives::vdf::VDF;
+use criterion::Criterion;
+use curv::BigInt;
+use class_group::ABDeltaTriple;
+
+fn benches_class(c: &mut Criterion) {
+    let bench_eval = |c: &mut Criterion, difficulty: &BigInt, a_b_delta: &ABDeltaTriple, seed: &BigInt| {
+        c.bench_function(&format!("eval with difficulty {}", difficulty), move |b| {
+            b.iter(|| VDF::eval(&a_b_delta, &seed, &difficulty))
+        });
+    };
+    let bench_verify =
+        |c: &mut Criterion, difficulty: &BigInt, vdf_out_proof: &VDF| {
+            c.bench_function(
+                &format!("verify with difficulty {}", difficulty),
+                move |b| b.iter(|| vdf_out_proof.verify()),
+            );
+        };
+
+    let sec = 1600;
+    const TEST_HASH: &str = "1eeb30c7163271850b6d018e8282093ac6755a771da6267edf6c9b4fce9242ba";
+    let seed = BigInt::from_str_radix(TEST_HASH, 16).unwrap();
+    let a_b_delta = VDF::setup(sec, &seed);
+
+    // change below to `for &i in &[1_000, 2_000, 5_000, 10_000, 100_000, 1_000_000] {` if needed to expand test cases,
+    // may also need to increase pari_init size (first parameter in `pari_init`) in src/primitives/vdf.rs 
+    for &i in &[1_0] {
+        // precompute for verification
+        let t = BigInt::from(i);
+        let vdf_out_proof = VDF::eval(&a_b_delta, &seed, &t);
+        let res = vdf_out_proof.verify();
+        assert!(res.is_ok());
+
+        bench_eval(c, &t, &a_b_delta, &seed);
+        bench_verify(c, &t, &vdf_out_proof)
+    }
+}
+
+criterion_group!(benches, benches_class);
+criterion_main!(benches);

--- a/benches/vdf/class_group.rs
+++ b/benches/vdf/class_group.rs
@@ -2,23 +2,23 @@
 extern crate criterion;
 
 use class_group::primitives::vdf::VDF;
+use class_group::ABDeltaTriple;
 use criterion::Criterion;
 use curv::BigInt;
-use class_group::ABDeltaTriple;
 
 fn benches_class(c: &mut Criterion) {
-    let bench_eval = |c: &mut Criterion, difficulty: &BigInt, a_b_delta: &ABDeltaTriple, seed: &BigInt| {
-        c.bench_function(&format!("eval with difficulty {}", difficulty), move |b| {
-            b.iter(|| VDF::eval(&a_b_delta, &seed, &difficulty))
-        });
-    };
-    let bench_verify =
-        |c: &mut Criterion, difficulty: &BigInt, vdf_out_proof: &VDF| {
-            c.bench_function(
-                &format!("verify with difficulty {}", difficulty),
-                move |b| b.iter(|| vdf_out_proof.verify()),
-            );
+    let bench_eval =
+        |c: &mut Criterion, difficulty: &BigInt, a_b_delta: &ABDeltaTriple, seed: &BigInt| {
+            c.bench_function(&format!("eval with difficulty {}", difficulty), move |b| {
+                b.iter(|| VDF::eval(&a_b_delta, &seed, &difficulty))
+            });
         };
+    let bench_verify = |c: &mut Criterion, difficulty: &BigInt, vdf_out_proof: &VDF| {
+        c.bench_function(
+            &format!("verify with difficulty {}", difficulty),
+            move |b| b.iter(|| vdf_out_proof.verify()),
+        );
+    };
 
     let sec = 1600;
     const TEST_HASH: &str = "1eeb30c7163271850b6d018e8282093ac6755a771da6267edf6c9b4fce9242ba";
@@ -26,7 +26,7 @@ fn benches_class(c: &mut Criterion) {
     let a_b_delta = VDF::setup(sec, &seed);
 
     // change below to `for &i in &[1_000, 2_000, 5_000, 10_000, 100_000, 1_000_000] {` if needed to expand test cases,
-    // may also need to increase pari_init size (first parameter in `pari_init`) in src/primitives/vdf.rs 
+    // may also need to increase pari_init size (first parameter in `pari_init`) in src/primitives/vdf.rs
     for &i in &[1_0] {
         // precompute for verification
         let t = BigInt::from(i);


### PR DESCRIPTION
This PR allows bench test VDF in class group by running
```
cargo test --lib vdf -- --test-threads=1     
```

## environment
+ Ubuntu 20.04.1 LTS
+ linux 5.4.0-48-generic
+ cargo 1.44.1 (88ba85757 2020-06-11)
+ rustup 1.22.1 (b01adbbc3 2020-07-08)
+ rustc 1.44.1 (c7087fe00 2020-06-17)

## how to test it
```
cargo test --lib vdf -- --test-threads=1     
```

## test result
```
eval with difficulty 10 time:   [11.250 ms 11.267 ms 11.286 ms]                                    
                        change: [+60.995% +62.097% +62.982%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe

verify with difficulty 10                                                                            
                        time:   [7.7320 ms 7.7783 ms 7.8527 ms]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
```