### PR TITLE
test(VDF): add bench tests for VDF in rsa group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,8 @@ sha2 = "0.9.1"
 name = "bench-vdf-class"
 path = "benches/vdf/class_group.rs"
 harness = false
+
+[[bench]]
+name = "bench-vdf-rsa"
+path = "benches/vdf/rsa_group.rs"
+harness = false

--- a/README.md
+++ b/README.md
@@ -41,13 +41,31 @@ Use `Cargo build`.
 The library uses bindings to PARI c library. Running `Cargo build` for the first time will take PARI from the _depend_ folder and install it on the machine. It was tested on MacOS and Linux. If you encounter a problem with installation of PARI, please open an issue and try to install it [manually](https://pari.math.u-bordeaux.fr/download.html). Bindings are generated automatically on the fly which might slow down the build procces by a few seconds.
 
 
-Test
+Unit-test
 -------------------
 Tests in rust are multi-thearded if possible. However, PARI configuration supports a single thread. Therefore to make sure all tests run with defined behaviour please use `cargo test  -- --test-threads=1`. 
 
 **Usage**
 
 We use tests to demonstrate correctness of each primitive: At the end of each primitive `.rs` file there is a test to show the correct usage of the primitive. There is usually one test or more to show soundness of the implementation, i.e. not knowing a witness will fail a PoK. For all tests we assume 128bit security (conservatively translates into 1600bit Discriminant).
+
+Bench-test
+-------------------
+Currenly this library supports benchmarking Wesolowski VDF in class_group vs in rsa_group. As aforementioned, PARI configuration only supports a single thread. To benchtest using PARI we need to use `--jobs 1` flag.
+
+You can change and expand the test cases in `benches/vdf/class_group.rs`. You may also need to increase pari_init size (first parameter in `pari_init`) in src/primitives/vdf.rs if testing a larger `t`. We recommend testing each case respectively (i.e., `for &i in &[1_000] {`, `for &i in &[2_000] {` ..., instead of `for &i in &[1_000, 2_000, 5_000] {`) if the memory is limited.
+
+**Usage**
+
+benchmarking class_group VDF:
+```
+cargo bench --bench bench-vdf-class  --jobs 1
+```
+
+benchmarking rsa_group VDF:
+```
+cargo bench --bench bench-vdf-rsa  --jobs 1
+```
 
 Security
 -------------------

--- a/benches/vdf/rsa_group.rs
+++ b/benches/vdf/rsa_group.rs
@@ -1,0 +1,139 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
+use rug::Integer;
+use sha2::{Digest, Sha256};
+
+/// algo_2 from the paper
+fn verify(modulus: &Integer, g: &Integer, t: u64, y: &Integer, pi: &Integer) -> bool {
+    let modulus = modulus.clone();
+
+    let l = hash_to_prime(&modulus, &[&g, &y]);
+
+    let r = Integer::from(2).pow_mod(&Integer::from(t), &l).unwrap();
+    let pi_l = pi.clone().pow_mod(&l, &modulus).unwrap();
+    let g_r = g.clone().pow_mod(&r, &modulus).unwrap();
+    let pi_l_g_r = pi_l * g_r;
+
+    Integer::from(pi_l_g_r.div_rem_floor(modulus.clone()).1) == y.clone()
+}
+
+/// algo_3 from the paper
+fn eval(modulus: &Integer, g: &Integer, t: u64) -> (Integer, Integer) {
+    let modulus = modulus.clone();
+
+    // y <- (g^2)^t
+    let mut y = g.clone();
+    for _ in 0..t {
+        y = y.clone() * y.clone();
+        y = y.div_rem_floor(modulus.clone()).1;
+    }
+
+    let l = hash_to_prime(&modulus, &[&g, &y]);
+
+    // algo_4 from the paper, long division
+    // TODO: consider algo_5 instead
+    let mut b: Integer;
+    let mut r = Integer::from(1);
+    let mut r2: Integer;
+    let two = Integer::from(2);
+    let mut pi = Integer::from(1);
+
+    for _ in 0..t {
+        r2 = r.clone() * two.clone();
+        b = r2.clone().div_rem_floor(l.clone()).0;
+        r = r2.clone().div_rem_floor(l.clone()).1;
+        let pi_2 = pi.clone().pow_mod(&two, &modulus).unwrap();
+        let g_b = g.clone().pow_mod(&b, &modulus).unwrap();
+        pi = pi_2 * g_b;
+    }
+    pi = Integer::from(pi.div_rem_floor(modulus.clone()).1);
+    (y, pi)
+}
+
+/// int(H("residue"||x)) mod N
+fn h_g(modulus: &Integer, seed: &Integer) -> Integer {
+    let modulus = modulus.clone();
+    let mut hasher = Sha256::new();
+    hasher.update("residue".as_bytes());
+    hasher.update(&seed.clone().to_string_radix(16).as_bytes());
+    let result_hex = hasher.finalize();
+    let result_hex_str = format!("{:#x}", result_hex);
+    let result_int = Integer::from_str_radix(&result_hex_str, 16).unwrap();
+
+    // inverse, to get enough security bits
+    match result_int.invert(&modulus.clone()) {
+        Ok(inverse) => inverse,
+        Err(unchanged) => unchanged,
+    }
+}
+
+fn hash_to_prime(modulus: &Integer, inputs: &[&Integer]) -> Integer {
+    let mut hasher = Sha256::new();
+    for input in inputs {
+        hasher.update(input.to_string_radix(16).as_bytes());
+        hasher.update("\n".as_bytes());
+    }
+    let hashed_hex = hasher.finalize();
+    let hashed_hex_str = format!("{:#x}", hashed_hex);
+    let hashed_int = Integer::from_str_radix(&hashed_hex_str, 16).unwrap();
+
+    // inverse, to get enough security bits
+    let inverse = match hashed_int.invert(&modulus.clone()) {
+        Ok(inverse) => inverse,
+        Err(unchanged) => unchanged,
+    };
+
+    Integer::from(inverse.next_prime().div_rem_floor(modulus.clone()).1)
+}
+
+fn benches_rsa(c: &mut Criterion) {
+    let bench_eval = |c: &mut Criterion, difficulty: u64, modulus: &Integer, seed: &Integer| {
+        c.bench_function(&format!("eval with difficulty {}", difficulty), move |b| {
+            b.iter(|| eval(&modulus, &seed, difficulty))
+        });
+    };
+    let bench_verify = |c: &mut Criterion,
+                        difficulty: u64,
+                        modulus: &Integer,
+                        seed: &Integer,
+                        y: &Integer,
+                        pi: &Integer| {
+        c.bench_function(
+            &format!("verify with difficulty {}", difficulty),
+            move |b| b.iter(|| verify(&modulus, &seed, difficulty, &y, &pi)),
+        );
+    };
+
+    /// RSA-2048 modulus, taken from [Wikipedia](https://en.wikipedia.org/wiki/RSA_numbers#RSA-2048).
+    pub const MODULUS: &str =
+    "251959084756578934940271832400483985714292821262040320277771378360436620207075955562640185258807\
+    8440691829064124951508218929855914917618450280848912007284499268739280728777673597141834727026189\
+    6375014971824691165077613379859095700097330459748808428401797429100642458691817195118746121515172\
+    6546322822168699875491824224336372590851418654620435767984233871847744479207399342365848238242811\
+    9816381501067481045166037730605620161967625613384414360383390441495263443219011465754445417842402\
+    0924616515723350778707749817125772467962926386356373289912154831438167899885040445364023527381951\
+    378636564391212010397122822120720357";
+    let modulus = Integer::from_str_radix(MODULUS, 10).unwrap();
+
+    const TEST_HASH: &str = "1eeb30c7163271850b6d018e8282093ac6755a771da6267edf6c9b4fce9242ba";
+    let seed_hash = Integer::from_str_radix(TEST_HASH, 16).unwrap();
+    let seed = Integer::from(seed_hash.div_rem_floor(modulus.clone()).1);
+
+    // g <- H_G(x)
+    let g = h_g(&modulus, &seed);
+
+    for &i in &[1_000, 2_000, 5_000, 10_000, 100_000, 1_000_000] {
+        // precompute for verification
+        let (y, pi) = eval(&modulus, &g, i);
+        let result = verify(&modulus, &g, i, &y, &pi);
+        assert!(result);
+
+        bench_eval(c, i, &modulus, &seed);
+        bench_verify(c, i, &modulus, &seed, &y, &pi)
+    }
+}
+
+criterion_group!(benches, benches_rsa);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds an exmaple of benchmarking VDF in rsa_group (using RSA-2048 modulus).

## environment
+ Ubuntu 20.04.1 LTS
+ linux 5.4.0-48-generic
+ cargo 1.44.1 (88ba85757 2020-06-11)
+ rustup 1.22.1 (b01adbbc3 2020-07-08)
+ rustc 1.44.1 (c7087fe00 2020-06-17)

## how to test it
```
cargo bench --bench bench-vdf-rsa  --jobs 1
```

## test result
```
Benchmarking eval with difficulty 1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 38.2s, or reduce sample count to 10.
eval with difficulty 1000                                                                            
                        time:   [378.84 ms 379.39 ms 380.08 ms]
                        change: [-0.9753% -0.6037% -0.2520%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

Benchmarking verify with difficulty 1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 55.9s, or reduce sample count to 10.
verify with difficulty 1000                                                                            
                        time:   [545.13 ms 545.60 ms 546.16 ms]
                        change: [-7.4577% -6.4547% -5.4789%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

Benchmarking eval with difficulty 2000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.2s, or reduce sample count to 90.
eval with difficulty 2000                                                                            
                        time:   [51.903 ms 51.967 ms 52.035 ms]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking verify with difficulty 2000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 15.0s, or reduce sample count to 30.
verify with difficulty 2000                                                                            
                        time:   [141.99 ms 142.08 ms 142.18 ms]
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) high mild

Benchmarking eval with difficulty 5000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 13.2s, or reduce sample count to 30.
eval with difficulty 5000                                                                            
                        time:   [125.14 ms 125.30 ms 125.48 ms]
Found 21 outliers among 100 measurements (21.00%)
  11 (11.00%) high mild
  10 (10.00%) high severe

Benchmarking verify with difficulty 5000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 52.3s, or reduce sample count to 10.
verify with difficulty 5000                                                                            
                        time:   [487.24 ms 487.65 ms 488.12 ms]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

Benchmarking eval with difficulty 10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 25.5s, or reduce sample count to 10.
eval with difficulty 10000                                                                            
                        time:   [252.55 ms 252.86 ms 253.21 ms]
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe

Benchmarking verify with difficulty 10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 31.9s, or reduce sample count to 10.
verify with difficulty 10000                                                                            
                        time:   [308.68 ms 309.44 ms 310.36 ms]
Found 20 outliers among 100 measurements (20.00%)
  16 (16.00%) high mild
  4 (4.00%) high severe

Benchmarking eval with difficulty 100000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 83.7s, or reduce sample count to 10.
eval with difficulty 100000                                                                            
                        time:   [842.41 ms 847.44 ms 853.19 ms]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

Benchmarking verify with difficulty 100000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 96.0s, or reduce sample count to 10.
verify with difficulty 100000                                                                            
                        time:   [948.37 ms 953.38 ms 959.61 ms]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

Benchmarking eval with difficulty 1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 694.4s, or reduce sample count to 10.
eval with difficulty 1000000                                                                            
                        time:   [6.9406 s 6.9448 s 6.9492 s]
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild

Benchmarking verify with difficulty 1000000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 16.1s, or reduce sample count to 30.
verify with difficulty 1000000                                                                            
                        time:   [158.90 ms 159.14 ms 159.43 ms]
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```
