### PR TITLE
Use curv from crates.io and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "class_group"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["omershlo <omer.shlomovits@gmail.com>"]
 edition = "2018"
 links = "libpari"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 ring-algorithm = "0.2.3"
 num-traits = "0.2"
-
-[dependencies.curv]
-git = "https://github.com/KZen-networks/curv"
-tag = "v0.6.2"
+curv = { package = "curv-kzen", version = "0.7" }
 
 [dev-dependencies]
 criterion = ">=0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use libc::c_char;
 use std::ffi::CStr;
 use std::mem::swap;
 use std::ops::Neg;
-use std::str;
+use std::{str, ptr};
 
 pub mod primitives;
 
@@ -172,8 +172,7 @@ impl BinaryQF {
         let pari_qf = self.qf_to_pari_qf();
         let pari_n = bn_to_gen(n);
 
-        let mut v = unsafe { std::mem::MaybeUninit::uninit().assume_init() };
-        let pari_qf_exp = unsafe { nupow(pari_qf, pari_n, &mut v) };
+        let pari_qf_exp = unsafe { nupow(pari_qf, pari_n, ptr::null_mut()) };
         let qf_exp = BinaryQF::pari_qf_to_qf(pari_qf_exp);
         qf_exp
     }


### PR DESCRIPTION
This also removes the use of uninitialized integers, which are Undefined Behavior in rust, and replaced with a NULL pointer because it's an optional out argument that we don't make use of anyway (if I understood their docs correctly)

Source: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
> An integer (i*/u*), floating point value (f*), or raw pointer obtained from uninitialized memory, or uninitialized memory in a str