### PR TITLE
Update build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ keywords = ["cryptography", "crypto", "libpari"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
 bindgen = "0.50"
+fs_extra = "1"
+anyhow = "1"
 
 [dependencies]
 libc = "0.2.0"

--- a/build.rs
+++ b/build.rs
@@ -1,51 +1,90 @@
 use std::collections::HashSet;
-extern crate bindgen;
-
 use std::env;
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::iter::FromIterator;
+use std::path::{Path, PathBuf};
 use std::process::Command;
-fn main() {
-    let pari_dir = "./depend/pari";
-    let pari_install = format!("{}/pari", env::var("OUT_DIR").unwrap());
+
+use anyhow::{anyhow, bail, Context};
+
+fn main() -> anyhow::Result<()> {
+    let out_dir = env::var("OUT_DIR").context("OUT_DIR env variable is not set")?;
+    let out_dir = Path::new(&out_dir);
+    let out_dir = fs::canonicalize(out_dir).context("canonicalize OUT_DIR")?;
+    println!("Out dir: {}", out_dir.to_string_lossy());
+
+    let pari_dir = PathBuf::from_iter([".", "depend", "pari"]);
+    let pari_mirror = out_dir.join("pari-mirror");
+    let pari_install = out_dir.join("pari-install");
+
+    println!(
+        "cargo:rerun-if-changed={}/CHANGES",
+        pari_dir.to_string_lossy()
+    );
+
+    // Create a copy of pari directory inside of OUT_DIR
     {
-        let path = fs::canonicalize(format!("{}/Configure", pari_dir)).unwrap();
-        let output = Command::new(path.to_str().unwrap())
-            .arg(format!("--prefix={}", &pari_install))
-            .current_dir(pari_dir)
+        if pari_mirror.exists() {
+            fs::remove_dir_all(&pari_mirror).context("remove mirror copy of pari")?;
+        }
+
+        let opts = fs_extra::dir::CopyOptions {
+            copy_inside: true,
+            ..Default::default()
+        };
+        fs_extra::dir::copy(&pari_dir, &pari_mirror, &opts)
+            .context("create a copy of pari directory to OUT_DIR")?;
+        // Ensure that the rest of build script doesn't refer to original pari directory by mistake
+        drop(pari_dir);
+    }
+
+    {
+        let output = Command::new(pari_mirror.join("Configure"))
+            .arg(OsString::from_iter([
+                OsStr::new("--prefix="),
+                pari_install.as_os_str(),
+            ]))
+            .current_dir(&pari_mirror)
             .output()
-            .expect("failed to execute process");
+            .context("run ./Configure")?;
 
         if !output.status.success() {
-            std::io::stderr().write_all(&output.stderr).unwrap();
-            panic!("PARI: failed to configure");
+            std::io::stderr()
+                .write_all(&output.stderr)
+                .context("write error to stderr")?;
+            bail!("./Configure returned non-zero code")
         }
     }
 
     {
         let output = Command::new("make")
             .arg("install-nodata")
-            .current_dir(pari_dir)
+            .current_dir(&pari_mirror)
             .output()
-            .expect("failed to make");
+            .context("run `make install-nodata`")?;
 
         if !output.status.success() {
-            std::io::stderr().write_all(&output.stderr).unwrap();
-            panic!("PARI: failed to ‘make install-nodata’");
+            std::io::stderr()
+                .write_all(&output.stderr)
+                .context("write error to stderr")?;
+            bail!("`make install-nodata` returned non-zero code");
         }
     }
 
     {
         let output = Command::new("make")
             .arg("install-lib-sta")
-            .current_dir(pari_dir)
+            .current_dir(&pari_mirror)
             .output()
-            .expect("failed to make");
+            .context("run `make install-lib-sta`")?;
 
         if !output.status.success() {
-            std::io::stderr().write_all(&output.stderr).unwrap();
-            panic!("PARI: failed to ‘make install-lib-sta’");
+            std::io::stderr()
+                .write_all(&output.stderr)
+                .context("write error to stderr")?;
+            bail!("`make install-lib-sta` returned non-zero code")
         }
     }
 
@@ -66,7 +105,10 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
-        .clang_arg(format!("-I{}/include", &pari_install))
+        .clang_arg(format!(
+            "-I{}",
+            pari_install.join("include").to_string_lossy()
+        ))
         .whitelist_type("GEN")
         .whitelist_function("mkintn")
         .whitelist_function("GENtostr")
@@ -83,18 +125,21 @@ fn main() {
         .parse_callbacks(Box::new(ignored_macros))
         // Finish the builder and generate the bindings.
         .generate()
-        // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
+        .map_err(|_| anyhow!("couldn't generate bindings"))?;
 
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+        .context("couldn't write bindings")?;
 
-    println!("cargo:rerun-if-changed={}/CHANGES", pari_dir);
-    println!("cargo:rustc-link-search=native={}/lib", pari_install);
+    println!(
+        "cargo:rustc-link-search=native={}/lib",
+        pari_install.to_string_lossy()
+    );
     println!("cargo:rustc-link-lib=static=pari");
+
+    Ok(())
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Main intention of PR is to publish this crate. Currently `build.rs` violates one of crates.io requirements: it modifies files outside of `OUT_DIR`. Violation happens when we run `./Configure` and `make install` of pari lib: it creates a bunch of makefiles, object files, and so on. The easiest solution I found is to simply copy entire `./depend/pari` to `OUT_DIR` and work with it.

Other changes: I replaced panicking with error propagation, and made paths construction idiomatic.